### PR TITLE
Feature/fix nvmm selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.7.x] - YYYY-MM-DD
+### Changed
+- check for cuda version >= 11 to enable nvmm code
+  * nvmm support implementation is only compatible to cuda >= 11
+  * fixes #60
+
 ## [0.7.0] - 2023-05-08
 
 ### Changed

--- a/ext/pylon/meson.build
+++ b/ext/pylon/meson.build
@@ -16,7 +16,7 @@ nvds_dep = cc.find_library('nvbufsurface',
     dirs: '/opt/nvidia/deepstream/deepstream/lib/',
     required: false
 )
-cuda_dep = dependency('cuda', version : '>=10', required: false)
+cuda_dep = dependency('cuda', version : '>=11', required: false)
 if nvds_dep.found() and cuda_dep.found()
   nvds_include = include_directories('/opt/nvidia/deepstream/deepstream/sources/includes/')
 


### PR DESCRIPTION
The current nvmm code only works for CUDA >= 11.0. 
This PR checks this condition.