### PR TITLE
terminate pylon after plugin scan phase

### DIFF
--- a/ext/pylon/gstpylonplugin.cpp
+++ b/ext/pylon/gstpylonplugin.cpp
@@ -34,9 +34,9 @@
 #  include "config.h"
 #endif
 
+#include "gstpylonsrc.h"
 #include "version.h"
 
-#include "gstpylonsrc.h"
 #include <pylon/PylonVersionNumber.h>
 
 static gboolean plugin_init(GstPlugin* plugin) {
@@ -44,9 +44,9 @@ static gboolean plugin_init(GstPlugin* plugin) {
                               GST_TYPE_PYLON_SRC);
 }
 
-GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR,
-    pylon,
-    "Basler/Pylon plugin for pylon SDK " PYLON_VERSIONSTRING_MAJOR "."
-    PYLON_VERSIONSTRING_MINOR "." PYLON_VERSIONSTRING_SUBMINOR "("
-    PYLON_VERSIONSTRING_BUILD ")", plugin_init, GIT_VERSION,
-    GST_PACKAGE_LICENSE, GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)
+GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, pylon,
+                  "Basler/Pylon plugin for pylon SDK " PYLON_VERSIONSTRING_MAJOR
+                  "." PYLON_VERSIONSTRING_MINOR "." PYLON_VERSIONSTRING_SUBMINOR
+                  "(" PYLON_VERSIONSTRING_BUILD ")",
+                  plugin_init, GIT_VERSION, GST_PACKAGE_LICENSE,
+                  GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)

--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -221,6 +221,7 @@ static void gst_pylon_src_class_init(GstPylonSrcClass *klass) {
   const gchar *cam_prolog = NULL;
   const gchar *stream_prolog = NULL;
 
+  /* prepare access to pylon */
   gst_pylon_initialize();
 
   /* Setting up pads and setting metadata should be moved to
@@ -387,10 +388,16 @@ static void gst_pylon_src_class_init(GstPylonSrcClass *klass) {
   base_src_class->query = GST_DEBUG_FUNCPTR(gst_pylon_src_query);
 
   push_src_class->create = GST_DEBUG_FUNCPTR(gst_pylon_src_create);
+
+  /* free pylon ressources */
+  gst_pylon_terminate();
 }
 
 static void gst_pylon_src_init(GstPylonSrc *self) {
   GstBaseSrc *base = GST_BASE_SRC(self);
+
+  /* prepare access to pylon */
+  gst_pylon_initialize();
 
   self->pylon = NULL;
   self->duration = GST_CLOCK_TIME_NONE;
@@ -541,6 +548,7 @@ static void gst_pylon_src_finalize(GObject *object) {
     self->stream = NULL;
   }
 
+  /* free pylon ressources */
   gst_pylon_terminate();
 
   G_OBJECT_CLASS(gst_pylon_src_parent_class)->finalize(object);


### PR DESCRIPTION
Pylon init and terminate was not properly balanced.

The PR adds the missing pair of  terminate and init  calls during plugin loading phase.