### PR TITLE
Fix buffer size for non-NVMM buffer when chunk enabled

### DIFF
--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -566,7 +566,7 @@ gboolean gst_pylon_capture(GstPylon *self, GstBuffer **buf,
         grab_result_ptr, static_cast<GDestroyNotify>(free_ptr_grab_result));
   } else {
 #endif
-    gsize buffer_size = (*grab_result_ptr)->GetBufferSize();
+    gsize buffer_size = (*grab_result_ptr)->GetImageSize();
     *buf = gst_buffer_new_wrapped_full(
         static_cast<GstMemoryFlags>(0), (*grab_result_ptr)->GetBuffer(),
         buffer_size, 0, buffer_size, grab_result_ptr,


### PR DESCRIPTION
When chunk data is active, GetBufferSize() returns the size of the image itself plus the chunk data. However, the GstBuffer should only contain the image data since the metadata is already parsed and put into the buffer's "Meta"s.

Tested using the pipeline `pylonsrc user-set=UserSet1 | bayer2rgb | filesink location=<...>` where UserSet1 has chunk data enabled. Previous behaviour was for bayer2rgb to fail because the buffer size did not match the expected size (width * height), now it works as expected.