### PR TITLE
Fix latency calculation

### DIFF
--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -875,10 +875,6 @@ static gboolean gst_pylon_src_query(GstBaseSrc *src, GstQuery *query) {
         min_latency = 0;
         max_latency = GST_CLOCK_TIME_NONE;
       } else {
-        /* FIXME: we are assuming we cannot hold more than one
-           buffer. Eventually we want to have Pylon::StartGrabbing's
-           MaxNumImages extend the max_latency.
-         */
         max_latency = min_latency = self->duration;
       }
 

--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -866,13 +866,14 @@ static gboolean gst_pylon_src_query(GstBaseSrc *src, GstQuery *query) {
 
   switch (GST_QUERY_TYPE(query)) {
     case GST_QUERY_LATENCY: {
-      GstClockTime min_latency = GST_CLOCK_TIME_NONE;
-      GstClockTime max_latency = GST_CLOCK_TIME_NONE;
+      GstClockTime min_latency;
+      GstClockTime max_latency;
 
       if (GST_CLOCK_TIME_NONE == self->duration) {
         GST_WARNING_OBJECT(
             src, "Can't report latency since framerate is not fixated yet");
-        max_latency = min_latency = 0;
+        min_latency = 0;
+        max_latency = GST_CLOCK_TIME_NONE;
       } else {
         /* FIXME: we are assuming we cannot hold more than one
            buffer. Eventually we want to have Pylon::StartGrabbing's


### PR DESCRIPTION
Return 0 when the latency is unknown to let the rest of the pipeline proceed. When it becomes known (the frame rate gets fixed), send a message to recompute the pipeline's latency.