### PR TITLE
Use pylon AutoInitTerm to handle lifetime

### DIFF
--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -147,10 +147,6 @@ static const std::vector<GstStPixelFormats> gst_structure_formats = {
     {"video/x-raw", pixel_format_mapping_raw},
     {"video/x-bayer", pixel_format_mapping_bayer}};
 
-void gst_pylon_initialize() { Pylon::PylonInitialize(); }
-
-void gst_pylon_terminate() { Pylon::PylonTerminate(); }
-
 static std::string gst_pylon_get_camera_fullname(
     Pylon::CBaslerUniversalInstantCamera &camera) {
   return std::string(camera.GetDeviceInfo().GetFullName());

--- a/ext/pylon/gstpylon.h
+++ b/ext/pylon/gstpylon.h
@@ -54,16 +54,12 @@ typedef enum {
 #  define PROP_NVSURFACE_LAYOUT_DEFAULT ENUM_PITCH
 #endif
 
-void gst_pylon_initialize();
-
 GstPylon *gst_pylon_new(GstElement *gstpylonsrc, const gchar *device_user_name,
                         const gchar *device_serial_number, gint device_index,
                         gboolean enable_correction, GError **err);
 gboolean gst_pylon_set_user_config(GstPylon *self, const gchar *user_set,
                                    GError **err);
 void gst_pylon_free(GstPylon *self);
-
-void gst_pylon_terminate();
 
 gboolean gst_pylon_start(GstPylon *self, GError **err);
 gboolean gst_pylon_stop(GstPylon *self, GError **err);

--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -54,6 +54,7 @@
 #include "gstpylonsrc.h"
 
 #include <gst/video/video.h>
+#include <pylon/PylonIncludes.h>
 
 struct _GstPylonSrc {
   GstPushSrc base_pylonsrc;
@@ -199,7 +200,7 @@ static GType gst_pylon_nvsurface_layout_enum_get_type(void) {
                                                ",height=" GST_VIDEO_SIZE_RANGE
                                                ",framerate"
                                                "=" GST_VIDEO_FPS_RANGE
-					       NVMM_GST_VIDEO_CAPS
+                                               NVMM_GST_VIDEO_CAPS
          )
     );
 // clang-format on
@@ -220,8 +221,6 @@ static void gst_pylon_src_class_init(GstPylonSrcClass *klass) {
   gchar *stream_blurb = NULL;
   const gchar *cam_prolog = NULL;
   const gchar *stream_prolog = NULL;
-
-  gst_pylon_initialize();
 
   /* Setting up pads and setting metadata should be moved to
      base_class_init if you intend to subclass this class. */
@@ -541,8 +540,6 @@ static void gst_pylon_src_finalize(GObject *object) {
     self->stream = NULL;
   }
 
-  gst_pylon_terminate();
-
   G_OBJECT_CLASS(gst_pylon_src_parent_class)->finalize(object);
 }
 
@@ -690,7 +687,8 @@ static gboolean gst_pylon_src_set_caps(GstBaseSrc *src, GstCaps *caps) {
     self->duration = GST_CLOCK_TIME_NONE;
   }
   GST_OBJECT_UNLOCK(self);
-  gst_element_post_message (GST_ELEMENT_CAST (self), gst_message_new_latency (GST_OBJECT_CAST (self)));
+  gst_element_post_message(GST_ELEMENT_CAST(self),
+                           gst_message_new_latency(GST_OBJECT_CAST(self)));
 
   ret = gst_pylon_stop(self->pylon, &error);
   if (FALSE == ret && error) {
@@ -783,11 +781,11 @@ static gboolean gst_pylon_src_start(GstBaseSrc *src) {
                               self->enable_correction, &error);
 #ifdef NVMM_ENABLED
   /* setup nvbufsurface if a new device has been created */
-  if(self->pylon){
-      gst_pylon_set_nvsurface_layout(
-          self->pylon,
-          static_cast<GstPylonNvsurfaceLayoutEnum>(self->nvsurface_layout));
-      gst_pylon_set_gpu_id(self->pylon, self->gpu_id);
+  if (self->pylon) {
+    gst_pylon_set_nvsurface_layout(
+        self->pylon,
+        static_cast<GstPylonNvsurfaceLayoutEnum>(self->nvsurface_layout));
+    gst_pylon_set_gpu_id(self->pylon, self->gpu_id);
   }
 #endif
   GST_OBJECT_UNLOCK(self);

--- a/ext/pylon/gstpylonsysmembufferfactory.h
+++ b/ext/pylon/gstpylonsysmembufferfactory.h
@@ -34,8 +34,8 @@
 #define GST_PYLON_SYSMEM_BUFFER_FACTORY_H
 
 #include <gst/gst.h>
+#include <gst/pylon/gstpylonincludes.h>
 #include <gstpylonbufferfactory.h>
-#include <pylon/PylonIncludes.h>
 
 class GstPylonSysMemBufferFactory : public GstPylonBufferFactory {
  public:

--- a/gst-libs/gst/pylon/gstpylonobject.cpp
+++ b/gst-libs/gst/pylon/gstpylonobject.cpp
@@ -50,6 +50,10 @@ static void gst_pylon_object_class_init(
     GstPylonObjectClass* klass, GstPylonObjectDeviceMembers* device_members);
 static gpointer gst_pylon_object_parent_class = NULL;
 static gint GstPylonObject_private_offset;
+
+/* manage lifetime of pylon sdk */
+Pylon::PylonAutoInitTerm autoInitTerm;
+
 static void gst_pylon_object_class_intern_init(
     gpointer klass, GstPylonObjectDeviceMembers* device_members) {
   gst_pylon_object_parent_class = g_type_class_peek_parent(klass);


### PR DESCRIPTION
The Pylon::AutoInitTerm singleton takes care of desctructing pylon before the library gets unloaded