### PR TITLE
Throughput limit property

### DIFF
--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -410,15 +410,43 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
   g_return_val_if_fail(err && *err == NULL, FALSE);
 
   try {
-    self->camera->DeviceLinkThroughputLimitMode.SetValue(Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
-    self->camera->DeviceLinkThroughputLimit.SetValue(62000000);
+    GenApi::INodeMap &nodemap = self->camera->GetNodeMap();
+
+    /* Try to set the mode parameter if it exists (may not exist on some models) */
+    try {
+      self->camera->DeviceLinkThroughputLimitMode.TrySetValue(
+          Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
+    } catch (const Pylon::GenericException &) {
+      /* DeviceLinkThroughputLimitMode may not exist on some models */
+    }
+
+    /* Try DeviceLinkThroughputLimit first */
+    try {
+      if (self->camera->DeviceLinkThroughputLimit.TrySetValue(62000000)) {
+        return TRUE;
+      }
+    } catch (const Pylon::GenericException &) {
+      /* DeviceLinkThroughputLimit may not exist, try alternative */
+    }
+
+    /* Fallback to DeviceMaxThroughput if DeviceLinkThroughputLimit doesn't exist */
+    try {
+      Pylon::CIntegerParameter device_max_throughput(nodemap, "DeviceMaxThroughput");
+      if (device_max_throughput.TrySetValue(62000000)) {
+        return TRUE;
+      }
+    } catch (const Pylon::GenericException &) {
+      /* DeviceMaxThroughput may not exist either */
+    }
+
+    /* If both fail, log info - some cameras may not support throughput limiting */
+    GST_INFO("Throughput limit parameters not available on this camera model");
+    return TRUE;
   } catch (const Pylon::GenericException &e) {
     g_set_error(err, GST_LIBRARY_ERROR, GST_LIBRARY_ERROR_FAILED, "%s",
                 e.GetDescription());
     return FALSE;
   }
-
-  return TRUE;
 }
 
 void gst_pylon_free(GstPylon *self) {

--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -429,13 +429,14 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
     }
 
     /* Check if GenICam compliant features are available */
-    gboolean has_limit_mode = (limit_mode_node != NULL) &&
-                              GenApi::IsImplemented(limit_mode_node);
-    gboolean has_limit = (limit_node != NULL) &&
-                         GenApi::IsImplemented(limit_node);
+    gboolean has_limit_mode =
+        (limit_mode_node != NULL) && GenApi::IsImplemented(limit_mode_node);
+    gboolean has_limit =
+        (limit_node != NULL) && GenApi::IsImplemented(limit_node);
 
     if (!has_limit_mode && !has_limit) {
-      GST_INFO("Throughput limit parameters not available on this camera model");
+      GST_INFO(
+          "Throughput limit parameters not available on this camera model");
       return TRUE;
     }
 
@@ -443,25 +444,25 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
      * DeviceLinkThroughputLimit */
     if (has_limit_mode && has_limit) {
       /* Check environment variable first - early return if not set */
-      const gchar *env_limit = g_getenv("RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT");
+      const gchar *env_limit = g_getenv("DEVICE_LINK_THROUGHPUT_LIMIT");
       if (env_limit == NULL) {
         GST_DEBUG(
-            "RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT not set, "
+            "DEVICE_LINK_THROUGHPUT_LIMIT not set, "
             "skipping DeviceLinkThroughputLimit configuration");
         return TRUE;
       }
 
       gint64 limit_value = g_ascii_strtoll(env_limit, NULL, 10);
       if (limit_value <= 0) {
-        GST_WARNING(
-            "Invalid value in RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT: %s",
-            env_limit);
+        GST_WARNING("Invalid value in DEVICE_LINK_THROUGHPUT_LIMIT: %s",
+                    env_limit);
         return TRUE;
       }
 
       try {
         /* Set DeviceLinkThroughputLimitMode to On */
-        Pylon::CEnumParameter limit_mode(nodemap, "DeviceLinkThroughputLimitMode");
+        Pylon::CEnumParameter limit_mode(nodemap,
+                                         "DeviceLinkThroughputLimitMode");
         if (limit_mode.IsWritable()) {
           limit_mode.SetValue("On");
           GST_DEBUG("Set DeviceLinkThroughputLimitMode to On");
@@ -476,7 +477,7 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
         if (limit.IsWritable()) {
           limit.SetValue(limit_value);
           GST_INFO("Set DeviceLinkThroughputLimit to %" G_GINT64_FORMAT
-                   " (from RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT)",
+                   " (from DEVICE_LINK_THROUGHPUT_LIMIT)",
                    limit_value);
         } else {
           GST_WARNING(
@@ -496,7 +497,8 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
       } else if (!has_limit_mode && has_limit) {
         GST_WARNING(
             "Camera has DeviceLinkThroughputLimit but not "
-            "DeviceLinkThroughputLimitMode. This camera may not be fully GenICam "
+            "DeviceLinkThroughputLimitMode. This camera may not be fully "
+            "GenICam "
             "compliant.");
       }
     }

--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -306,6 +306,9 @@ GstPylon *gst_pylon_new(GstElement *gstpylonsrc, const gchar *device_user_name,
       gst_pylon_apply_set(self, default_set);
     }
 
+    self->camera->DeviceLinkThroughputLimitMode.SetValue(Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
+    self->camera->DeviceLinkThroughputLimit.SetValue(62000000);
+
     GenApi::INodeMap &cam_nodemap = self->camera->GetNodeMap();
     self->gcamera = gst_pylon_object_new(
         self->camera, gst_pylon_get_camera_fullname(*self->camera),

--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -306,9 +306,6 @@ GstPylon *gst_pylon_new(GstElement *gstpylonsrc, const gchar *device_user_name,
       gst_pylon_apply_set(self, default_set);
     }
 
-    self->camera->DeviceLinkThroughputLimitMode.SetValue(Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
-    self->camera->DeviceLinkThroughputLimit.SetValue(62000000);
-
     GenApi::INodeMap &cam_nodemap = self->camera->GetNodeMap();
     self->gcamera = gst_pylon_object_new(
         self->camera, gst_pylon_get_camera_fullname(*self->camera),
@@ -402,6 +399,22 @@ gboolean gst_pylon_set_pfs_config(GstPylon *self, const gchar *pfs_location,
   } catch (const Pylon::GenericException &e) {
     g_set_error(err, GST_LIBRARY_ERROR, GST_LIBRARY_ERROR_FAILED,
                 "PFS file error: %s", e.GetDescription());
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
+  g_return_val_if_fail(self, FALSE);
+  g_return_val_if_fail(err && *err == NULL, FALSE);
+
+  try {
+    self->camera->DeviceLinkThroughputLimitMode.SetValue(Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
+    self->camera->DeviceLinkThroughputLimit.SetValue(62000000);
+  } catch (const Pylon::GenericException &e) {
+    g_set_error(err, GST_LIBRARY_ERROR, GST_LIBRARY_ERROR_FAILED, "%s",
+                e.GetDescription());
     return FALSE;
   }
 

--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -405,9 +405,16 @@ gboolean gst_pylon_set_pfs_config(GstPylon *self, const gchar *pfs_location,
   return TRUE;
 }
 
-gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
+gboolean gst_pylon_set_throughput_limit(GstPylon *self, guint64 limit_value,
+                                        GError **err) {
   g_return_val_if_fail(self, FALSE);
   g_return_val_if_fail(err && *err == NULL, FALSE);
+
+  /* Early return if limit_value is 0 (not set) */
+  if (limit_value == 0) {
+    GST_DEBUG("Device link throughput limit not set, skipping configuration");
+    return TRUE;
+  }
 
   try {
     GenApi::INodeMap &nodemap = self->camera->GetNodeMap();
@@ -443,22 +450,6 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
     /* GenICam compliant path: use DeviceLinkThroughputLimitMode and
      * DeviceLinkThroughputLimit */
     if (has_limit_mode && has_limit) {
-      /* Check environment variable first - early return if not set */
-      const gchar *env_limit = g_getenv("DEVICE_LINK_THROUGHPUT_LIMIT");
-      if (env_limit == NULL) {
-        GST_DEBUG(
-            "DEVICE_LINK_THROUGHPUT_LIMIT not set, "
-            "skipping DeviceLinkThroughputLimit configuration");
-        return TRUE;
-      }
-
-      gint64 limit_value = g_ascii_strtoll(env_limit, NULL, 10);
-      if (limit_value <= 0) {
-        GST_WARNING("Invalid value in DEVICE_LINK_THROUGHPUT_LIMIT: %s",
-                    env_limit);
-        return TRUE;
-      }
-
       try {
         /* Set DeviceLinkThroughputLimitMode to On */
         Pylon::CEnumParameter limit_mode(nodemap,
@@ -476,8 +467,7 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
         Pylon::CIntegerParameter limit(nodemap, "DeviceLinkThroughputLimit");
         if (limit.IsWritable()) {
           limit.SetValue(limit_value);
-          GST_INFO("Set DeviceLinkThroughputLimit to %" G_GINT64_FORMAT
-                   " (from DEVICE_LINK_THROUGHPUT_LIMIT)",
+          GST_INFO("Set DeviceLinkThroughputLimit to %" G_GUINT64_FORMAT,
                    limit_value);
         } else {
           GST_WARNING(

--- a/ext/pylon/gstpylon.cpp
+++ b/ext/pylon/gstpylon.cpp
@@ -412,35 +412,95 @@ gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err) {
   try {
     GenApi::INodeMap &nodemap = self->camera->GetNodeMap();
 
-    /* Try to set the mode parameter if it exists (may not exist on some models) */
+    /* Check for GenICam compliant features */
+    GenApi::INode *limit_mode_node = NULL;
+    GenApi::INode *limit_node = NULL;
+
     try {
-      self->camera->DeviceLinkThroughputLimitMode.TrySetValue(
-          Basler_UniversalCameraParams::DeviceLinkThroughputLimitMode_On);
+      limit_mode_node = nodemap.GetNode("DeviceLinkThroughputLimitMode");
     } catch (const Pylon::GenericException &) {
-      /* DeviceLinkThroughputLimitMode may not exist on some models */
+      /* Node doesn't exist */
     }
 
-    /* Try DeviceLinkThroughputLimit first */
     try {
-      if (self->camera->DeviceLinkThroughputLimit.TrySetValue(62000000)) {
+      limit_node = nodemap.GetNode("DeviceLinkThroughputLimit");
+    } catch (const Pylon::GenericException &) {
+      /* Node doesn't exist */
+    }
+
+    /* Check if GenICam compliant features are available */
+    gboolean has_limit_mode = (limit_mode_node != NULL) &&
+                              GenApi::IsImplemented(limit_mode_node);
+    gboolean has_limit = (limit_node != NULL) &&
+                         GenApi::IsImplemented(limit_node);
+
+    if (!has_limit_mode && !has_limit) {
+      GST_INFO("Throughput limit parameters not available on this camera model");
+      return TRUE;
+    }
+
+    /* GenICam compliant path: use DeviceLinkThroughputLimitMode and
+     * DeviceLinkThroughputLimit */
+    if (has_limit_mode && has_limit) {
+      /* Check environment variable first - early return if not set */
+      const gchar *env_limit = g_getenv("RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT");
+      if (env_limit == NULL) {
+        GST_DEBUG(
+            "RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT not set, "
+            "skipping DeviceLinkThroughputLimit configuration");
         return TRUE;
       }
-    } catch (const Pylon::GenericException &) {
-      /* DeviceLinkThroughputLimit may not exist, try alternative */
-    }
 
-    /* Fallback to DeviceMaxThroughput if DeviceLinkThroughputLimit doesn't exist */
-    try {
-      Pylon::CIntegerParameter device_max_throughput(nodemap, "DeviceMaxThroughput");
-      if (device_max_throughput.TrySetValue(62000000)) {
+      gint64 limit_value = g_ascii_strtoll(env_limit, NULL, 10);
+      if (limit_value <= 0) {
+        GST_WARNING(
+            "Invalid value in RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT: %s",
+            env_limit);
         return TRUE;
       }
-    } catch (const Pylon::GenericException &) {
-      /* DeviceMaxThroughput may not exist either */
+
+      try {
+        /* Set DeviceLinkThroughputLimitMode to On */
+        Pylon::CEnumParameter limit_mode(nodemap, "DeviceLinkThroughputLimitMode");
+        if (limit_mode.IsWritable()) {
+          limit_mode.SetValue("On");
+          GST_DEBUG("Set DeviceLinkThroughputLimitMode to On");
+        } else {
+          GST_WARNING(
+              "DeviceLinkThroughputLimitMode is not writable on this camera");
+          return TRUE;
+        }
+
+        /* Set DeviceLinkThroughputLimit */
+        Pylon::CIntegerParameter limit(nodemap, "DeviceLinkThroughputLimit");
+        if (limit.IsWritable()) {
+          limit.SetValue(limit_value);
+          GST_INFO("Set DeviceLinkThroughputLimit to %" G_GINT64_FORMAT
+                   " (from RVAI_SIDECAR_DEVICE_LINK_THROUGHPUT_LIMIT)",
+                   limit_value);
+        } else {
+          GST_WARNING(
+              "DeviceLinkThroughputLimit is not writable on this camera");
+        }
+      } catch (const Pylon::GenericException &e) {
+        GST_WARNING("Failed to set GenICam throughput limit features: %s",
+                    e.GetDescription());
+      }
+    } else {
+      /* Partial GenICam compliance - log warning */
+      if (has_limit_mode && !has_limit) {
+        GST_WARNING(
+            "Camera has DeviceLinkThroughputLimitMode but not "
+            "DeviceLinkThroughputLimit. This camera may not be fully GenICam "
+            "compliant.");
+      } else if (!has_limit_mode && has_limit) {
+        GST_WARNING(
+            "Camera has DeviceLinkThroughputLimit but not "
+            "DeviceLinkThroughputLimitMode. This camera may not be fully GenICam "
+            "compliant.");
+      }
     }
 
-    /* If both fail, log info - some cameras may not support throughput limiting */
-    GST_INFO("Throughput limit parameters not available on this camera model");
     return TRUE;
   } catch (const Pylon::GenericException &e) {
     g_set_error(err, GST_LIBRARY_ERROR, GST_LIBRARY_ERROR_FAILED, "%s",

--- a/ext/pylon/gstpylon.h
+++ b/ext/pylon/gstpylon.h
@@ -74,7 +74,8 @@ gboolean gst_pylon_set_configuration(GstPylon *self, const GstCaps *conf,
                                      GError **err);
 gboolean gst_pylon_set_pfs_config(GstPylon *self, const gchar *pfs_location,
                                   GError **err);
-gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err);
+gboolean gst_pylon_set_throughput_limit(GstPylon *self, guint64 limit_value,
+                                        GError **err);
 gchar *gst_pylon_camera_get_string_properties();
 gchar *gst_pylon_stream_grabber_get_string_properties();
 

--- a/ext/pylon/gstpylon.h
+++ b/ext/pylon/gstpylon.h
@@ -74,6 +74,7 @@ gboolean gst_pylon_set_configuration(GstPylon *self, const GstCaps *conf,
                                      GError **err);
 gboolean gst_pylon_set_pfs_config(GstPylon *self, const gchar *pfs_location,
                                   GError **err);
+gboolean gst_pylon_set_throughput_limit(GstPylon *self, GError **err);
 gchar *gst_pylon_camera_get_string_properties();
 gchar *gst_pylon_stream_grabber_get_string_properties();
 

--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -69,6 +69,7 @@ struct _GstPylonSrc {
   gchar *pfs_location;
   gboolean enable_correction;
   GstPylonCaptureErrorEnum capture_error;
+  guint64 device_link_throughput_limit;
   GObject *cam;
   GObject *stream;
 
@@ -110,6 +111,7 @@ enum {
   PROP_PFS_LOCATION,
   PROP_ENABLE_CORRECTION,
   PROP_CAPTURE_ERROR,
+  PROP_DEVICE_LINK_THROUGHPUT_LIMIT,
   PROP_CAM,
   PROP_STREAM,
 #ifdef NVMM_ENABLED
@@ -129,6 +131,9 @@ enum {
 #define PROP_CAM_DEFAULT NULL
 #define PROP_STREAM_DEFAULT NULL
 #define PROP_CAPTURE_ERROR_DEFAULT ENUM_ABORT
+#define PROP_DEVICE_LINK_THROUGHPUT_LIMIT_DEFAULT 0
+#define PROP_DEVICE_LINK_THROUGHPUT_LIMIT_MIN 0
+#define PROP_DEVICE_LINK_THROUGHPUT_LIMIT_MAX G_MAXUINT64
 #ifdef NVMM_ENABLED
 #  define PROP_GPU_ID_MIN 0
 #  define PROP_GPU_ID_MAX G_MAXUINT32
@@ -311,6 +316,21 @@ static void gst_pylon_src_class_init(GstPylonSrcClass *klass) {
           GST_TYPE_CAPTURE_ERROR_ENUM, PROP_CAPTURE_ERROR_DEFAULT,
           static_cast<GParamFlags>(G_PARAM_READWRITE |
                                    GST_PARAM_CONTROLLABLE)));
+
+  g_object_class_install_property(
+      gobject_class, PROP_DEVICE_LINK_THROUGHPUT_LIMIT,
+      g_param_spec_uint64(
+          "device-link-throughput-limit", "Device link throughput limit",
+          "Sets the device link throughput limit in bytes per second. "
+          "If set to 0 (default), the throughput limit is not configured. "
+          "Requires GenICam compliant DeviceLinkThroughputLimitMode and "
+          "DeviceLinkThroughputLimit features.",
+          PROP_DEVICE_LINK_THROUGHPUT_LIMIT_MIN,
+          PROP_DEVICE_LINK_THROUGHPUT_LIMIT_MAX,
+          PROP_DEVICE_LINK_THROUGHPUT_LIMIT_DEFAULT,
+          static_cast<GParamFlags>(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
+                                   GST_PARAM_MUTABLE_READY)));
+
 #ifdef NVMM_ENABLED
   g_object_class_install_property(
       gobject_class, PROP_NVSURFACE_LAYOUT,
@@ -401,6 +421,8 @@ static void gst_pylon_src_init(GstPylonSrc *self) {
   self->pfs_location = PROP_PFS_LOCATION_DEFAULT;
   self->enable_correction = PROP_ENABLE_CORRECTION_DEFAULT;
   self->capture_error = PROP_CAPTURE_ERROR_DEFAULT;
+  self->device_link_throughput_limit =
+      PROP_DEVICE_LINK_THROUGHPUT_LIMIT_DEFAULT;
   self->cam = PROP_CAM_DEFAULT;
   self->stream = PROP_STREAM_DEFAULT;
   gst_video_info_init(&self->video_info);
@@ -448,6 +470,9 @@ static void gst_pylon_src_set_property(GObject *object, guint property_id,
       self->capture_error =
           static_cast<GstPylonCaptureErrorEnum>(g_value_get_enum(value));
       break;
+    case PROP_DEVICE_LINK_THROUGHPUT_LIMIT:
+      self->device_link_throughput_limit = g_value_get_uint64(value);
+      break;
 #ifdef NVMM_ENABLED
     case PROP_NVSURFACE_LAYOUT:
       self->nvsurface_layout =
@@ -494,6 +519,9 @@ static void gst_pylon_src_get_property(GObject *object, guint property_id,
       break;
     case PROP_CAPTURE_ERROR:
       g_value_set_enum(value, self->capture_error);
+      break;
+    case PROP_DEVICE_LINK_THROUGHPUT_LIMIT:
+      g_value_set_uint64(value, self->device_link_throughput_limit);
       break;
 #ifdef NVMM_ENABLED
     case PROP_NVSURFACE_LAYOUT:
@@ -821,7 +849,8 @@ static gboolean gst_pylon_src_start(GstBaseSrc *src) {
   /* Set throughput limit after UserSet and PFS file are loaded to ensure
    * it's not overridden */
   GST_OBJECT_LOCK(self);
-  ret = gst_pylon_set_throughput_limit(self->pylon, &error);
+  ret = gst_pylon_set_throughput_limit(
+      self->pylon, self->device_link_throughput_limit, &error);
   GST_OBJECT_UNLOCK(self);
 
   if (ret == FALSE && error) {

--- a/ext/pylon/gstpylonsrc.cpp
+++ b/ext/pylon/gstpylonsrc.cpp
@@ -818,6 +818,16 @@ static gboolean gst_pylon_src_start(GstBaseSrc *src) {
     goto log_gst_error;
   }
 
+  /* Set throughput limit after UserSet and PFS file are loaded to ensure
+   * it's not overridden */
+  GST_OBJECT_LOCK(self);
+  ret = gst_pylon_set_throughput_limit(self->pylon, &error);
+  GST_OBJECT_UNLOCK(self);
+
+  if (ret == FALSE && error) {
+    goto log_gst_error;
+  }
+
   self->duration = GST_CLOCK_TIME_NONE;
 
   goto out;


### PR DESCRIPTION
During our use of this plugin, it became apparent that setting the device link throughput limit as documented [here](https://docs.baslerweb.com/network-related-parameters) in situations that the OS is under heavy load. Unfortunately, this setting cannot be set through the configuration file. Therefore the suggestion is to expose the setting through this plugin.