### PR TITLE
Detect and support NVMM on Nvidia Jetson

### DIFF
--- a/ext/pylon/meson.build
+++ b/ext/pylon/meson.build
@@ -12,13 +12,23 @@ pylon_sources = [
   'gstpylonsysmembufferfactory.cpp',
 ]
 
+fs = import('fs')
+
+if fs.is_dir('/usr/src/jetson_multimedia_api/include/')
+    nvds_lib_dir = '/usr/lib/aarch64-linux-gnu/tegra'
+    nvds_inc_dir = '/usr/src/jetson_multimedia_api/include/'
+else
+    nvds_lib_dir = '/opt/nvidia/deepstream/deepstream/lib/'
+    nvds_inc_dir = '/opt/nvidia/deepstream/deepstream/sources/includes/'
+endif
+
 nvds_dep = cc.find_library('nvbufsurface',
-    dirs: '/opt/nvidia/deepstream/deepstream/lib/',
+    dirs: nvds_lib_dir,
     required: false
 )
 cuda_dep = dependency('cuda', version : '>=11', required: false)
 if nvds_dep.found() and cuda_dep.found()
-  nvds_include = include_directories('/opt/nvidia/deepstream/deepstream/sources/includes/')
+  nvds_include = include_directories(nvds_inc_dir)
 
   pylon_sources += ['gstpylondsnvmmbufferfactory.cpp']
 


### PR DESCRIPTION
Update meson.build to find nvbufsurface on Jetson so to build with NVMM support. Ideas from https://github.com/basler/gst-plugin-pylon/issues/82

The dependencies can be installed: `sudo apt install nvidia-l4t-jetson-multimedia-api cuda-cudart-dev-13-2` (for Jetpack 7) or `sudo apt install nvidia-l4t-jetson-multimedia-api cuda-cudart-dev-12-6` (for Jetpack 6)